### PR TITLE
Add trailing ampersand to a2jmidid call from Qjackctl.

### DIFF
--- a/_manual/03_setting-up-your-system/05_setting-up-midi/02_midi-on-linux.html
+++ b/_manual/03_setting-up-your-system/05_setting-up-midi/02_midi-on-linux.html
@@ -68,8 +68,7 @@ to start JACK.
 
 <p>
 For other versions of JACK,
-add <kbd class="input">a2jmidid -e</kbd> as an "after start-up" script
+add <kbd class="input">a2jmidid -e &amp;</kbd> as an "after start-up" script
 in the <kbd class="menu">Setup &gt; Options</kbd> tab of QJackCtl, so
 that it is started automatically whenever you start JACK.
 </p>
-


### PR DESCRIPTION
Without this, qjackctl will freeze.

(Haven't been able to actually test this change since I can't get the jekyll setup to work, but I'm hoping this should be simple enough...)