### PR TITLE
Add extender documentation and clarification to Surfaces.

### DIFF
--- a/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol.html
+++ b/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol.html
@@ -21,7 +21,9 @@ menu_title: Mackie/Logic Control Devices
 <img src="" alt="Mackie Control Setup Dialog" />
 <p>
   From the selector at the top, choose the type of device you are using. 
-  (<a href="/missing">What do do if your device is not listed</a>).
+  (<a
+  href="devices-using-mackielogic-control-protocol/devices_not_listed.html">
+  What do do if your device is not listed</a>).
 </p>
 <p>
   Once your setup is complete, click "OK" to close the dialog. Now click 

--- a/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol/04_devices_not_listed.html
+++ b/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol/04_devices_not_listed.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: What to if your Device is not Listed
+menu_title: Unlisted devices
+---                        
+
+<p>
+  All Mackie Control devices are based on the original Logic Control and the
+  documentation in the user manual that came with it. The Mackie Control and
+  the Mackie Control Pro and so on, all use this same protocol. Any units
+  from other manufactures will also use the same encoding as best the
+  hardware will allow. If the unit in use has more than one Mackie Control
+  option, it is best to choose Logic Control or LC. Any Templates for the
+  buttons should be chosen the same way as the Function key Editor uses these
+  button names. The "Mackie Control" option should be considered default and
+  should be tried with any unlisted device before attemping to create a
+  custom definition file.
+</p>

--- a/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol/05_working_with_extenders.html
+++ b/_manual/22_using-control-surfaces/02_devices-using-mackielogic-control-protocol/05_working_with_extenders.html
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Working With Extenders
+menu_title: Working With Extenders
+---                        
+
+<p>
+  Extenders will require a custom file as there are no combinations listed
+  at this time. The best way is to start with the mc.device file and copy it
+  to a new name such as xt+mc.device and then edit that file. It is best to
+  name the file with the order the devices are expected to be used in as
+  the position of the master device is specified in this file.
+</p>
+<p>
+  The two lines of interest are:
+<p>
+<pre>
+ &gt;Extenders value="0"/&gt;
+ &gt;MasterPosition value="0"/&gt;
+</pre>
+<p>
+  Add these two lines if they are not present. The <code>Extenders</code>
+  value is the number of extenders used and should not include the master in
+  that number. That is, it should be the total number of units minus 1. The
+  <code>MasterPosition</code> value is the position from left to right where
+  the master unit (with the master fader) is, starting at 0. So if there are
+  three surfaces, <code>MasterPosition</code> with value 0 would be master
+  on the left, <code>MasterPosition</code> with value 1 would be master in
+  the middle and <code>MasterPosition</code> with value 2 would be master on
+  the right.
+</p>
+<p>
+  If the <code>MasterPosition</code> value does not properly match the
+  physcal position and MIDI port, the master fader and global controls will
+  not work. The master unit will act like an extender.
+</p>

--- a/_manual/22_using-control-surfaces/03_midi-binding-maps.html
+++ b/_manual/22_using-control-surfaces/03_midi-binding-maps.html
@@ -115,6 +115,14 @@ bindings"&gt;
   <code>pgm</code>  (to create a binding for a Program Change message).
 </p>
 <p>
+  <code>enc-r</code>, <code>enc-l</code>, <code>enc-2</code> and
+  <code>enc-b</code> may be used for surfaces that have encoders that send
+  offsets rather than values. These accept Continuous Controller messages
+  but treat them as offsets. These are good for banked controls as they are
+  always at the right spot to start adjusting. See the link at the bottom of
+  the page for a longer explanation.
+</p>
+<p>
   You can also bind sysex messages:
 </p>
 <code>
@@ -359,3 +367,4 @@ bindings"&gt;
   (the channel range may change at some point).
 </p>
   
+{% children %}

--- a/_manual/22_using-control-surfaces/03_midi-binding-maps.html
+++ b/_manual/22_using-control-surfaces/03_midi-binding-maps.html
@@ -138,6 +138,13 @@ bindings"&gt;
   some oddly designed control devices.
 </p>
 
+<h5>Note:<h5>
+<p>
+  The <code>sysex=</code> and <code>msg=</code> bindings will only work with
+  <code>function=</code> or <code>action=</code> control addresses. They
+  will <em>not</em> work with the <code>uri=</code> control addresses.
+</p>
+
 <h4>Control address</h4>
 <p>
   A <dfn>control address</dfn> defines what the binding will actually control. 

--- a/_manual/22_using-control-surfaces/03_midi-binding-maps.html
+++ b/_manual/22_using-control-surfaces/03_midi-binding-maps.html
@@ -138,8 +138,12 @@ bindings"&gt;
   some oddly designed control devices.
 </p>
 
-<h5>Note:<h5>
-<p>
+<p class="note">
+  It is not possible at this time to use multi-event MIDI strings such as
+  two event CC messages, RPN or NRPN.
+</p>
+
+<p class="note">
   The <code>sysex=</code> and <code>msg=</code> bindings will only work with
   <code>function=</code> or <code>action=</code> control addresses. They
   will <em>not</em> work with the <code>uri=</code> control addresses.

--- a/_manual/22_using-control-surfaces/03_midi-binding-maps/01_working-with-encoders.html
+++ b/_manual/22_using-control-surfaces/03_midi-binding-maps/01_working-with-encoders.html
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Working With Encoders in Ardour
+menu_title: Working With Encoders
+---
+
+<p>
+  Encoders are showing up more frequently on controllers. However, they use
+  the same MIDI events as Continuous Controllers and they have no standard
+  way of working. Ardour has implemented 4 of the more common ways of
+  sending encoder information.
+</p>
+<p>
+  Encoders that send the same continuous values as a pot would are not
+  discussed here as they work the same.
+</p>
+<P>
+  Encoders as this page talks about them send direction and offset that the
+  DAW will add to or subtract from the current value.
+</p>
+<p>
+  The 4 kinds of encoder supported are:
+</p>
+<ul>
+<li>
+  enc-r - On the bcr/bcf2000 this is called "Relative Signed Bit". The most
+  significant bit sets positive and the lower 6 signifcant bits are the
+  offset.
+</li>
+<li>
+  enc-l - The bcr2000 calls this "Relative Signed Bit 2". The most
+  significant bit sets negative and the lower 6 signifcant bits are the
+  offset. If you are using one of these two and the values are right but
+  reversed, use the other. This one is the one the Mackie Control Protocol
+  uses.
+</li>
+<li>
+  enc-2 - The bcr2000 calls this one "Relative 2s Complement". Positive
+  offsets are sent as normal from 1 to 64 and negative offsets are sent as
+  2s complement negative numbers.
+</li>
+<li>
+  enc-b - The bcr2000 calls this one "Relative Binary Offset". Positive
+  offsets are sent as offset plus 64 and negative offsets are sent as 64
+  minus offset.
+</li>
+<p>
+  If the wrong one is chosen, either the positive or negative side will act
+  incorrectly. It is not really possible to auto detect which one the
+  controller is using. Trial and error is the only way if the specification
+  of the controller is not known.
+</p>
+<p>
+  Many controllers have more than one choice as well, check the manual for
+  the surface.
+</p>


### PR DESCRIPTION
Added Documentation about how to use extenders with the Mackie Control Protocol Control Surfaces.
Added missing "What do do if your device is not listed" link and file.
Added note to MIDI Binding Maps that uri lines will not work with sysex= or msg= bindings.
Added note to MIDI Binding Maps that multi-event midi messages will not work.
 - high resolution CC messages
 - RPN messages
 - NRPN messages

Changed above notes to use class="note" to match style guide.