### PR TITLE
Fix than/then typo.

### DIFF
--- a/include/muting-and-soloing.html
+++ b/include/muting-and-soloing.html
@@ -85,7 +85,7 @@
 </p>
 <p>
   In this scheme Solo has no effect other than to mute other non-soloed tracks;
-  with solo (rather then listen), the monitor out is fed from the master bus.
+  with solo (rather than listen), the monitor out is fed from the master bus.
 </p>
 
 <h2>Other solo options</h2>


### PR DESCRIPTION
These two words are very close in their appearance, but than vs. then have very different uses. Then is commonly used to express a sense of time or what comes next or used to be. Than is used to form comparisons between two things.