### PR TITLE
Update from Windows XP to Windows 10 locations

### DIFF
--- a/include/files-and-directories-ardour-knows-about.html
+++ b/include/files-and-directories-ardour-knows-about.html
@@ -65,7 +65,7 @@
 </p>
 <p class="note">
   The above is only an example and may not even be true for all installations
-  of Windows XP.
+  of Windows 10.
 </p>
 
 <h2>Plugins</h2>

--- a/include/files-and-directories-ardour-knows-about.html
+++ b/include/files-and-directories-ardour-knows-about.html
@@ -59,8 +59,8 @@
   a real path.
 </p>
 <p>
-  An example of a configuration path in Window (from XP) would be:
-  <code>C:\Documents and Settings\&lt;User&gt;\Application Data\Local Settings\Ardour5\</code>
+  An example of a configuration path in Window 10 would be:
+  <code>C:\&lt;User&gt;\AppData\Local\Ardour5\</code>
   The user in the path would be the user's account name.
 </p>
 <p class="note">
@@ -146,8 +146,8 @@
 </p>
 <h4>LV2</h4>
 <p>
-  The LV2 standard for Windows is <code>%APPDATA%/LV2/</code> or
-  <code>%COMMONPROGRAMFILES%/LV2/</code>
+  The LV2 standard for Windows is <code>%APPDATA%/LV2/</code> (On Windows 10: <code>C:\&lt;User&gt;\AppData\Roaming\LV2\</code>)<or
+  <code>%COMMONPROGRAMFILES%/LV2/</code> (On Windows 10: <code>C:\Program Files\LV2\</code>).
 </p>
 
 <h2>Project Directory</h2>


### PR DESCRIPTION
Removed Windows XP file locations and replaced with file locations using in everything after XP (Windows 7-10).