### PR TITLE
Fixed automation language for modes and states

### DIFF
--- a/include/automation-mode.html
+++ b/include/automation-mode.html
@@ -1,0 +1,24 @@
+
+<p>
+  Ardour offers two modes for connecting automation points: <kbd
+  class=menu>Discrete</kbd> and <kbd class=menu>Linear</kbd>. To change the mode
+  right click on the automation lane header and choose your mode from the mode
+  menu.
+</p>
+
+<p>
+  <kbd class=menu>Discrete</kbd> mode has stair steps between each point on the
+  automation track. This is useful for on-off automation like mute or sustain
+  pedal (on a piano MIDI track).
+</p>
+
+<p>
+  If you record automation via MIDI (for example a pitch bend from a keyboard),
+  Ardour always uses discreet mode.
+</p>
+
+<p>
+  <kbd class=menu>Linear</kbd> mode has straight lines betwen each point on the
+  automation track. This is useful when you want gradual shifts in your
+  automation lanes, such as gradual increase in volume on the fader.
+</p>

--- a/include/automation-mode.html
+++ b/include/automation-mode.html
@@ -1,6 +1,6 @@
 
 <p>
-  Ardour offers two modes for connecting automation points: <kbd
+  Ardour offers two modes for connecting automation control points: <kbd
   class=menu>Discrete</kbd> and <kbd class=menu>Linear</kbd>. To change the mode
   right click on the automation lane header and choose your mode from the mode
   menu.
@@ -21,4 +21,7 @@
   <kbd class=menu>Linear</kbd> mode has straight lines betwen each point on the
   automation track. This is useful when you want gradual shifts in your
   automation lanes, such as gradual increase in volume on the fader.
+
+  Linear is the default mode for most automation lanes created via mouse input
+  (versus recording via MIDI).
 </p>

--- a/include/automation-nomenclature.html
+++ b/include/automation-nomenclature.html
@@ -13,6 +13,7 @@
   trim, etc. <dfn>Automation curves</dfn> consist of lines connected by
   <dfn>control points</dfn>, that live within the confines of a lane; these
   tell Ardour how to change a given parameter over time. <dfn>Automation
-  modes</dfn> govern how a given automation lane will behave during playback.
+	modes</dfn> specify whether the control points are connected by lines or
+	stair steps. <dfn>Automation states</dfn> govern how a given automation lane
+	will behave during playback. 
 </p>
-

--- a/include/automation-states.html
+++ b/include/automation-states.html
@@ -1,30 +1,30 @@
 
 <p>
   In order to understand how automation in Ardour works, it is necessary to
-  understand the four modes of automation. They are: <kbd
+  understand the four states of automation. They are: <kbd
   class=menu>Manual</kbd>, <kbd class=menu>Play</kbd>, <kbd
   class=menu>Write</kbd>, and <kbd class=menu>Touch</kbd>.
 </p>
 
 <figure class=right>
 <img src="/images/automation-modes1.png">
-<figcaption class=center>The automation mode menu.</figcaption>
+<figcaption class=center>The automation state menu.</figcaption>
 </figure>
 
 <p>
-  <kbd class=menu>Manual</kbd> mode is basically analogous to a processor's
-  bypass switch. Whenever an automation lane is in this mode, it is inactive
+  <kbd class=menu>Manual</kbd> state is basically analogous to a processor's
+  bypass switch. Whenever an automation lane is in this state, it is inactive
   and any level that is manually set for controlling the lane's parameter will
   persist during playback like normal.
 </p>
 
 <p class=note>
   In Ardour, every track and processor parameter is initially set to <kbd
-  class=menu>Manual</kbd> mode.
+  class=menu>Manual</kbd> state.
 </p>
 
 <p>
-  <kbd class=menu>Play</kbd> mode tells Ardour to use the automation curve in
+  <kbd class=menu>Play</kbd> state tells Ardour to use the automation curve in
   the automation lane to control the level of the parameter controlled by the
   lane <em>during playback</em>. The control that normally sets the parameter
   will be <em>unresponsive to manual input</em> and will move automatically in
@@ -32,7 +32,7 @@
 </p>
 
 <p>
-  <kbd class=menu>Write</kbd> mode allows continuous, dynamic setting of a
+  <kbd class=menu>Write</kbd> state allows continuous, dynamic setting of a
   control during playback; all such settings are written to the lane the
   control is in. This defines the lane's automation curve in the interval being
   played, and overwrites any existing automation curve in the lane being
@@ -40,10 +40,9 @@
 </p>
 
 <p>
-  <kbd class=menu>Touch</kbd> mode is similar to <kbd class=menu>Write</kbd>
+  <kbd class=menu>Touch</kbd> state is similar to <kbd class=menu>Write</kbd>
   mode, except it only overwrites sections of a lane's automation curve when
   the control is changed in some way. This allows for changing only the parts
   of an automation curve that are desired to be changed, while leaving the rest
   unchanged.
 </p>
-

--- a/master-doc.txt
+++ b/master-doc.txt
@@ -1740,6 +1740,13 @@ part: subchapter
 ---
 
 ---
+title: Automation States
+include: automation-states.html
+link: automation-states
+part: subchapter
+---
+
+---
 title: Automation Modes
 include: automation-modes.html
 link: automation-modes


### PR DESCRIPTION
Added a page about automation modes and reworded to use states instead of modes (to match the UI in Ardour) when referring to play, right, manual, etc. 