### PR TITLE
Fix a broken sentence

### DIFF
--- a/include/latency-and-latency-compensation.html
+++ b/include/latency-and-latency-compensation.html
@@ -65,7 +65,8 @@
 <p>
   Processing latency is usually divided into <dfn>capture latency</dfn> (the time
   it takes for the digitized audio to be available for digital processing, usually
-  one audio period), and <dfn>playback latency</dfn> (the time it takes for
+  one audio period), and <dfn>playback latency</dfn> (the time it takes for the
+  audio that has been processed to be available in digital form).
   In practice, the combination of both matters. It is called <dfn>round-trip
   latency</dfn>: the time necessary for a certain audio event to be captured,
   processed and played back.


### PR DESCRIPTION
The second part of the composed processing latency was interrupted mid-sentence. This proposal fixes that.