### PR TITLE
Update mnemonic-bindings-for-os-x.html

### DIFF
--- a/include/mnemonic-bindings-for-os-x.html
+++ b/include/mnemonic-bindings-for-os-x.html
@@ -26,11 +26,11 @@
 <tr><th>stop and destroy</th>
 <td><kbd class="mod1">space</kbd></td></tr>
 <tr><th>toggle auto play</th>
-<td><kbd class="">5</kbd></td></tr>
+<td><kbd class="mod1">7</kbd></td></tr>
 <tr><th>toggle auto return</th>
-<td><kbd class="">6</kbd></td></tr>
-<tr><th>toggle click (metronome)</th>
 <td><kbd class="">7</kbd></td></tr>
+<tr><th>toggle click (metronome)</th>
+<td><kbd class="">``</kbd></td></tr>
 <tr><th>toggle playhead follows edits</th>
 <td><kbd class="mod3">f</kbd></td></tr>
 <tr><th>toggle playhead tracking</th>
@@ -53,7 +53,7 @@
 <tr><th>add track(s) or bus(ses)</th>
 <td><kbd class="mod13">n</kbd></td></tr>
 <tr><th>export session</th>
-<td><kbd class="mod1">e</kbd></td></tr>
+<td><kbd class="mod2">e</kbd></td></tr>
 <tr><th>import audio files</th>
 <td><kbd class="mod1">i</kbd></td></tr>
 <tr><th>open a new session</th>
@@ -117,18 +117,22 @@
 <tr><th>show rhythm ferret window </th>
 <td><kbd class="mod2">f</kbd></td></tr>
 <tr><th>toggle big clock</th>
-<td><kbd class="mod2">b</kbd></td></tr>
-<tr><th>toggle color manager</th>
 <td><kbd class="mod2">c</kbd></td></tr>
+<tr><th>toggle color manager</th>
+<td></td></tr>
+<tr><th>toggle meterbridge</th>
+<td><kbd class="mod2">b</kbd></td></tr>
 <tr><th>toggle editor window</th>
-<td><kbd class="mod2">e</kbd></td></tr>
+<td><kbd class="mod2">m</kbd></td></tr>
 <tr><th>toggle global audio patchbay</th>
 <td><kbd class="mod2">p</kbd></td></tr>
 <tr><th>toggle global midi patchbay</th>
-<td><kbd class="mod23">p</kbd></td></tr>
+<td></td></tr>
+<tr><th>toggle midi connections</th>
+<td><kbd class="mod23">m</kbd></td></tr>
 <tr><th>toggle key bindings editor</th>
 <td><kbd class="mod2">k</kbd></td></tr>
-<tr><th>toggle preferences dialog</th>
+<tr><th>toggle session properties</th>
 <td><kbd class="mod2">o</kbd></td></tr>
 <tr><th>toggle preferences dialog</th>
 <td><kbd class="mod13">p</kbd></td></tr>
@@ -148,8 +152,10 @@
 <tr><th>EP to prev region sync</th>
 <td><kbd class="">'</kbd></td></tr>
 <tr><th>cycle to next grid snap mode</th>
-<td><kbd class="">2</kbd></td></tr>
+<td><kbd class="">5</kbd></td></tr>
 <tr><th>cycle to next zoom focus</th>
+<td></td></tr>
+<tr><th>cycle edit mode</th>
 <td><kbd class="">1</kbd></td></tr>
 <tr><th>insert from region list</th>
 <td><kbd class="">i</kbd></td></tr>
@@ -160,7 +166,7 @@
 <tr><th>next EP w/marker</th>
 <td><kbd class="mod1">^</kbd></td></tr>
 <tr><th>next EP w/o marker</th>
-<td><kbd class="">`</kbd></td></tr>
+<td></td></tr>
 <tr><th>trim back</th>
 <td><kbd class="">k</kbd></td></tr>
 <tr><th>trim front</th>
@@ -174,13 +180,13 @@
 <tr><th>trim region to start of next region</th>
 <td><kbd class="mod1">k</kbd></td></tr>
 <tr><th>use previous grid unit</th>
-<td><kbd class="">3</kbd></td></tr>
+<td><kbd class="">5</kbd></td></tr>
 <tr><th>use next grid unit</th>
+<td><kbd class="">6</kbd></td></tr>
+<tr><th>toggle smart mode</th>
+<td><kbd class="">3</kbd></td></tr>
+<tr><th>toggle snap</th>
 <td><kbd class="">4</kbd></td></tr>
-<tr><th>use previous grid unit</th>
-<td><kbd class="mod1">3</kbd></td></tr>
-<tr><th>use next musical grid unit</th>
-<td><kbd class="mod1">4</kbd></td></tr>
 </table>
 
 <h2>Aligning with the Edit Point</h2>
@@ -231,15 +237,15 @@
 <tr><th>duplicate region (once)</th>
 <td><kbd class="mod2">d</kbd></td></tr>
 <tr><th>export selected region(s)</th>
-<td></td></tr>
+<td><kbd class="mod12">e</td></tr>
 <tr><th>increase region gain</th>
 <td><kbd class="">^</kbd></td></tr>
 <tr><th>move to original position</th>
-<td><kbd class="mod2">o</kbd></td></tr>
-<tr><th>mute/unmute</th>
+<td></td></tr>
+<tr><th>mute/unmute (monitor)</th>
 <td><kbd class="mod1">m</kbd></td></tr>
 <tr><th>normalize</th>
-<td><kbd class="">n</kbd></td></tr>
+<td><kbd class="mod2">3</kbd></td></tr>
 <tr><th>nudge backward</th>
 <td><kbd class="kp">&ndash;</kbd></td></tr>
 <tr><th>nudge forward</th>
@@ -249,21 +255,21 @@
 <tr><th>reduce region gain</th>
 <td><kbd class="">&amp;</kbd></td></tr>
 <tr><th>reverse</th>
-<td><kbd class="mod2">r</kbd></td></tr>
+<td><kbd class="mod2">4</kbd></td></tr>
 <tr><th>set fade in length</th>
-<td><kbd class="">/</kbd></td></tr>
+<td><kbd class="mod1">/</kbd></td></tr>
 <tr><th>set fade out length</th>
-<td><kbd class="">\</kbd></td></tr>
+<td><kbd class="mod1">\</kbd></td></tr>
 <tr><th>set region sync point</th>
 <td><kbd class="">v</kbd></td></tr>
 <tr><th>split</th>
 <td><kbd class="">s</kbd></td></tr>
 <tr><th>toggle fade in active</th>
-<td><kbd class="mod1">/</kbd></td></tr>
+<td></td></tr>
 <tr><th>toggle fade out active</th>
-<td><kbd class="mod1">\</kbd></td></tr>
+<td></td></tr>
 <tr><th>transpose</th>
-<td><kbd class="mod2">t</kbd></td></tr>
+<td><kbd class="mod2">8</kbd></td></tr>
 </table>
 
 <h2>Generic Editing</h2>
@@ -303,7 +309,7 @@
 <tr><th>convert edit range to range</th>
 <td><kbd class="">F6</kbd></td></tr>
 <tr><th>invert selection</th>
-<td><kbd class="mod3">i</kbd></td></tr>
+<td><kbd class="mod1">Shift+i</kbd></td></tr>
 <tr><th>select all after EP</th>
 <td><kbd class="mod1">Shift+e</kbd></td></tr>
 <tr><th>select all before EP</th>
@@ -326,11 +332,11 @@
 <tr><th>set loop range from edit range</th>
 <td><kbd class="">]</kbd></td></tr>
 <tr><th>set loop range from region(s)</th>
-<td><kbd class="mod2">]</kbd></td></tr>
+<td><kbd class="">]</kbd></td></tr>
 <tr><th>set punch range from edit range</th>
 <td><kbd class="">[</kbd></td></tr>
 <tr><th>set punch range from region(s)</th>
-<td><kbd class="mod2">[</kbd></td></tr>
+<td><kbd class="">[</kbd></td></tr>
 <tr><th>set tempo (1 bar) from edit range</th>
 <td><kbd class="">0</kbd></td></tr>
 <tr><th>set tempo (1 bar) from region(s)</th>


### PR DESCRIPTION
There follows a list of changes I have made, 
then a list of shortcuts that either don't work, or I can't make them work (perhaps I don't understand them) but I haven't changed them

1. Changes
toggle auto play : from 5 to Cmd 7 
toggle auto return : from 6 to 7 
toggle click (metronome) : from 7 to `   
toggle big clock : from Ctrl B to Ctrl C 
toggle color manager : from Ctrl C to blank 
(ADDED) toggle meterbridge : Ctrl B 
toggle editor window : from Ctrl E to Ctrl M 
toggle global midi patchbay Ctrl Shift P : to toggle midi connections Ctrl Shift M 
toggle preferences dialog Ctrl O :  to toggle Session Properties Ctrl O 
export session : from Cmd E to Ctrl E
cycle to next grid snap mode : from 2 to 5 
cycle to next zoom focus 1 : to blank 
(ADDED)  cycle edit mode 1 
next EP w/o marker from ` to blank 
use previous grid unit: from 3 to 5 
use next musical grid unit: from 4 to 6 
(ADDED)  toggle smart mode 3 
(ADDED)  toggle snap 4 
export selected region(s) : from blank to Ctrl Cmd E 
move to original position : from Ctrl O to blank 
mute/unmute Cmd M : to mute/unmute (monitor) Cmd M 
normalize : from N to Ctrl 3 
reverse : from Ctrl R to Ctrl 4 
set fade in length: from / to Cmd /  
set fade out length:  from \ to Cmd \  
toggle fade in active : Cmd / to blank
toggle fade out active : Cmd \ to blank 
transpose from T to Ctrl 8 
invert selection from Shift I to Cmd Shift I 
set loop range from region(s) : from Ctrl ] to ] (as above) 
set punch range from region(s)  : from Ctrl [ to [ (as above) 

2. unchanged but not working or maybe not working
destroy last recording:  Cmd Del 
engage record: shift R
stop & destroy : Cmd Space [check - this is OS X standard binding for Spotlight]
play from EP & return : Cmd Space [check - this is OS X standard binding for Spotlight]
move EP to playhead: Ctrl Return
toggle playhead follows edits
zoom height to selected region(s) Cmd Ctrl Z
zoom height and time to selected region Ctrl Z
insert from region list: I
insert time Cmd T
next EP w/marker: Ctrl ^   [there’s no caret key except Ctrl Shift 6 & this doesn’t seem to do anything]
trim (various) - not sure how to get these to work - nothing happens
increase region gain:  ^  [no caret key on mac keyboard as above]
quantize MIDI notes: Q
reduce region gain: & [no ‘&’ on mac keyboard key and shift 7 doesn’t do anything]
Selecting
…all after playhead
…all before playhead
…convert edit range to range
select next track/bus: Ctrl downarrow [keybinding used by Mac OS system]
select previous track/bus: Ctrl uparrow [keybinding used by Mac OS system]