### PR TITLE
Update bindings alt + e

### DIFF
--- a/include/mnemonic-bindings-for-linux.html
+++ b/include/mnemonic-bindings-for-linux.html
@@ -128,7 +128,7 @@
 <td><kbd class="mod2">b</kbd></td></tr>
 <tr><th>toggle color manager</th>
 <td><kbd class="mod2">c</kbd></td></tr>
-<tr><th>toggle editor window</th>
+<tr><th>Export to Audio File(s)</th>
 <td><kbd class="mod2">e</kbd></td></tr>
 <tr><th>toggle global audio patchbay</th>
 <td><kbd class="mod2">p</kbd></td></tr>


### PR DESCRIPTION
alt + e exports audio by default now.