### PR TITLE
Update Transport Menu to match Ardour 6.5

### DIFF
--- a/include/the-transport-menu.html
+++ b/include/the-transport-menu.html
@@ -73,12 +73,13 @@
 	<tr><th>[] Punch In/Out</th><td>Based on the Punch in and Punch out markers if they exist, tells Ardour to record only between those two points</td></tr>
 	<tr><th>[] Punch In</th><td>Based on the Punch in marker, only allow to record from this point on</td></tr>
 	<tr><th>[] Punch Out</th><td>Based on the Punch out marker, forbids recording before this point</td></tr>
-	<tr><th>[] Audio Input</th><td>If checked, automatically switch the <a href="@@monitor-setup-in-ardour">monitor</a> from <em>input</em> to <em>playback</em>mode when playing</td></tr>
-	<tr><th>[] Follow Edits</th><td>If checked, selecting a region moves the playhead to its beginning</td></tr>
+	<tr><th>[] Auto Input</th><td>If checked, automatically switch the <a href="@@monitor-setup-in-ardour">monitor</a> from <em>input</em> to <em>playback</em>mode when playing</td></tr>
+	<tr><th>[] Follow Range</th><td>If checked, selecting a range moves the playhead to its beginning</td></tr>
 	<tr><th>[] Auto Play</th><td>If checked, moving the playhead in the ruler starts the playback</td></tr>
 	<tr><th>[] Auto Return</th><td>If checked, when the playback is stopped, go back to the previous position of the playhead. If not, the playhead stays where it is when the playback is stopped</td></tr>
 	<tr><th>[] Click</th><td>Activates/deactivates the click track (metronome)</td></tr>
 	<tr><th>[] Follow Playhead</th><td>If checked, while playing, when the playhead reaches the right of the screen, Ardour scrolls one screen to the right to keep the playhead visible at all times</td></tr>
 	<tr><th>[] Stationary Playhead</th><td>If checked <em>and</em> if <kbd class="menu">Follow playhead</kbd> is checked, on playback, the playhead stays at the center of the screen, and the session scrolls</td></tr>
+	<tr><th>[] Use External Positional Sync Source</th><td> If checked, allows Ardour to be controlled by external program</td></tr>
 	<tr><th>Panic</th><td>Immediately stops all MIDI playback (useful e.g. when a MIDI bug in encountered)</td></tr>
 </table>


### PR DESCRIPTION
-Specifically removed the [] follow edits option as it is no longer available and changed it to follow range.