### PR TITLE
Remove ampersand

### DIFF
--- a/include/loudness-analyzer.html
+++ b/include/loudness-analyzer.html
@@ -1,5 +1,5 @@
 <p>
-  The Loudness Analyzer &amp; Normalizer is a tool that is useful at the
+  The Loudness Analyzer and Normalizer is a tool that is useful at the
   end of the mixing process to make the final audio file comply with
   different specs regarding loudness.
 </p>

--- a/master-doc.txt
+++ b/master-doc.txt
@@ -1645,7 +1645,7 @@ part: section
 ---
 
 ---
-title: Loudness Analyzer & Normalizer
+title: Loudness Analyzer and Normalizer
 include: loudness-analyzer.html
 link: loudness-analyzer
 part: subchapter
@@ -1793,7 +1793,7 @@ part: chapter
 ---
 
 ---
-title: Transcoding, Formats &amp; Codecs
+title: Transcoding, Formats and Codecs
 include: transcoding-formats-amp-codecs.html
 link: transcoding-formats-amp-codecs
 uri: video-timeline/transcoding_formats_codecs
@@ -1801,7 +1801,7 @@ part: chapter
 ---
 
 ---
-title: Workflow &amp; Operations
+title: Workflow and Operations
 include: workflow-amp-operations.html
 link: workflow-amp-operations
 uri: video-timeline/operations


### PR DESCRIPTION
The ampersand in the font chosen for the manual doesn't really look like an ampersand, so this removes it and replaces it with the word 'and' instead.