### PR TITLE
Updated MIDI configuration page

### DIFF
--- a/include/configuring-midi.html
+++ b/include/configuring-midi.html
@@ -26,25 +26,16 @@
   <td><dfn><abbr title="Advanced Linux Sound API">ALSA</abbr> MIDI</dfn> is the
   standard MIDI framework on Linux systems.</td></tr>
   <tr><th>Windows</th>
-  <td>There is no single standard MIDI framework on Windows, but Ardour
-  can work with ASIO and others.</td></tr>
+  <td><dfn><abbr title="Microsoft Multimedia Environment">MME</abbr></dfn> is the standard
+  MIDI framework on Windows systems.</td></tr>
 </table>
 
 <p class="note">
-  On Linux systems, <dfn>QJackCtl</dfn> control software displays ALSA MIDI
-  ports under its "ALSA" tab (it does not currently display CoreMIDI ports).
-  By contrast, JACK MIDI ports show up under the <kbd class="menu">MIDI</kbd>
-  tab in QJackCtl. However, when Ardour is using jackd for audio in and out
-  the alsa MIDI ports are not accessable. When Ardour is using ALSA for audio
-  in and out then only alsa MIDI ports are accessable.
+  <dfn><abbr title="JACK Audio Connection Kit">JACK</abbr></dfn> is an
+  alternate audio system which Ardour can utilize for both audio and
+  MIDI.  JACK is used to route audio between independent applications,
+  and is now considered an advanced use case which is not recommended
+  for most users.  Users with a need to use JACK for audio routing
+  should consult the latest documentation at
+  the <a href="https://jackaudio.org/">JACK website</a>.
 </p>
-
-<h2>JACK MIDI Configuration</h2>
-
-<p>
-  By default, JACK will <strong>not</strong> automatically detect and use
-  existing MIDI ports. One of several ways of <dfn>bridging</dfn> between
-  the native MIDI frameworks (e.g. CoreMIDI or ALSA) and JACK MIDI must be
-  chosen, as described in the following sections.
-</p>
-

--- a/include/devices-using-mackielogic-control-protocol.html
+++ b/include/devices-using-mackielogic-control-protocol.html
@@ -44,9 +44,8 @@
 <h2>Connecting control surface and Ardour MIDI ports</h2>
 <p>
   Before attempting to use a Mackie Control device that communicates via
-  a standard MIDI cable or a USB cable, you should ensure that
-  <a href="@@midi-on-linux">your Linux
-  MIDI environment is setup</a>.
+  a standard MIDI cable or a USB cable, you should ensure that your MIDI
+  environment is setup.
   If you are using a device that uses normal MIDI (via a standard MIDI or
   USB cable), you need to connect Ardour's Mackie Control in and out ports
   to the MIDI ports leading to and coming from the control surface.

--- a/include/devices-using-mackielogic-control-protocol.html
+++ b/include/devices-using-mackielogic-control-protocol.html
@@ -44,8 +44,8 @@
 <h2>Connecting control surface and Ardour MIDI ports</h2>
 <p>
   Before attempting to use a Mackie Control device that communicates via
-  a standard MIDI cable or a USB cable, you should ensure that your MIDI
-  environment is setup.
+  a standard MIDI cable or a USB cable, you should ensure that
+  <a href="@@configuring-midi">your MIDI environment is setup</a>.
   If you are using a device that uses normal MIDI (via a standard MIDI or
   USB cable), you need to connect Ardour's Mackie Control in and out ports
   to the MIDI ports leading to and coming from the control surface.

--- a/master-doc.txt
+++ b/master-doc.txt
@@ -302,22 +302,6 @@ part: chapter
 ---
 
 ---
-title: MIDI on Linux
-include: midi-on-linux.html
-link: midi-on-linux
-uri: setting-up-your-system/setting-up-midi/midi-on-linux
-part: subchapter
----
-
----
-title: MIDI on OS X
-include: midi-on-os-x.html
-link: midi-on-os-x
-uri: setting-up-your-system/setting-up-midi/midi-on-os-x
-part: subchapter
----
-
----
 title: Ardour's Interface
 uri: ardours-interface
 part: part


### PR DESCRIPTION
MIDI configuration updated based on IRC discussion to remove mention of jackd configuration.
There are several other places in the manual which still mention JACK, those will need to be reviewed separately.

The MIDI on Linux and MIDI on OS X pages were not removed from git yet, but are not currently linked in the master doc.
After reviewing the manual and the Audio/MIDI setup dialog the MIDI on Linux page may need to be linked again, or possibly just additional info in the main MIDI setup page with OS specific notes.
Specifically the MIDI setup on Linux still requires the user to choose raw or seq device, but the manual has no mention of why you would choose one over the other, and the setup dialog does  not have any hints or tooltips either.
Also currently no mention of setting up MIDI latency on the MIDI configuration page.
If there are any OS X MIDI options someone else will need to review, I do not have an OS X machine to check.