### PR TITLE
Clarifying in which mode changes can be edited

### DIFF
--- a/include/patch-change.html
+++ b/include/patch-change.html
@@ -46,7 +46,7 @@
 <h2>Modifying Patch Changes</h2>
 
 <p>
-  A patch change can be modified by <kbd class="mouse">right</kbd>-clicking on
+  A patch change can be modified in <a href="@@toolbox">Internal Edit Mode</a> by <kbd class="mouse">right</kbd>-clicking on
   it, then selecting the desired patch from the menu that appears. A patch
   change can also be modified by hovering the mouse pointer over the patch
   change to be modified and moving the mouse wheel until the desired program


### PR DESCRIPTION
The above paragraph suggests that all changes are done in the Grab Mode instead of the Internal Edit Mode. It isn't intuitive to change the mode from G to E to edit the patch changes in view of the documentation and several users ran into this problem: https://discourse.ardour.org/t/how-do-i-modify-delete-a-patch-change/88413 https://discourse.ardour.org/t/g-e-mousemode-colors/89766

The documentation is clarified that while insertion happens in G mode, modification hapens in E mode.