### PR TITLE
WIP/Draft Change Font!

### DIFF
--- a/source/css/screen.css
+++ b/source/css/screen.css
@@ -1,12 +1,7 @@
-@font-face {
-    font-family: 'junge-regular';
-    src: url('../css/junge-regular-webfont.ttf')  format('truetype');
-    font-weight: normal;
-    font-style: normal;
-}
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap');
 
 body {
-  font-family: 'junge-regular';
+  font-family: 'Roboto';
   font-size: 16px;
 }
 


### PR DESCRIPTION
# Consider this an issue

Hi. I wanted to create an issue, but there is no button to create issues.

![image](https://github.com/user-attachments/assets/a1216cf2-1157-4369-aa14-d35fc809c05d)

# The problem
I usually browse the web very easily on my desktop, and all good, but with Ardour manual, I always need to zoom in one level on my browser. The font "feels empty" and hard to read both on light and dark theme.

One solution would be increasing font-size, but changing the font is a better solution here.

# How it currently looks like

This is how it currently looks like on both light and dark themes:

![image](https://github.com/user-attachments/assets/610a876a-48cf-45fe-bb51-674cd7a85c7b)

![image](https://github.com/user-attachments/assets/c3228371-01a4-4cba-88bf-8dca10564d74)

# How it would look like with Roboto

Compare with above

![image](https://github.com/user-attachments/assets/f88d71f3-a8db-493e-998b-4b34ad54c95b)

![image](https://github.com/user-attachments/assets/681270f7-7987-4ac5-9ec1-e60918c6437b)


# Other options than ROboto?

Here I have prepared a list of most used fonts on Google Fonts with screenshots from all of them on 16px. 16px is the font-size on Ardour's manual website

https://fonts.google.com/specimen/Roboto?preview.text=This%20is%20Roboto%20Font

![image](https://github.com/user-attachments/assets/610df4c7-00dd-4d4e-a242-ba1465dc838f)

https://fonts.google.com/specimen/Open+Sans?preview.text=This%20is%20Open%20Sans%20Font

![image](https://github.com/user-attachments/assets/960a478a-21ef-4fa5-8d6c-37df494ea35c)

https://fonts.google.com/specimen/Montserrat?preview.text=This%20is%20Montserrat%20Font

![image](https://github.com/user-attachments/assets/e41c2706-8960-4bba-9cb3-74816b97f18d)

https://fonts.google.com/specimen/Poppins?preview.text=This%20is%20Poppins%20Font

![image](https://github.com/user-attachments/assets/e9d21eaa-3c53-4a89-a950-69bc49b425a8)

https://fonts.google.com/specimen/Lato?preview.text=This%20is%20Lato%20Font

![image](https://github.com/user-attachments/assets/a227c21b-1420-4be5-a5b9-f7f3abe8ffb8)

https://fonts.google.com/specimen/Inter?preview.text=This%20is%20Inter%20Font

![image](https://github.com/user-attachments/assets/13093b8b-f158-4883-8be6-72fcdb7981c6)



And this is the Junge which we curerntly use. Note that it does not have different font-weights:

https://fonts.google.com/specimen/Junge?preview.text=This%20is%20Junge%20Font

![image](https://github.com/user-attachments/assets/a7d084c1-e93e-4058-b2c9-7c524021ec19)

