### PR TITLE
A workaround for the middle click on macOS.

### DIFF
--- a/include/move-regions-with-the-mouse.html
+++ b/include/move-regions-with-the-mouse.html
@@ -35,3 +35,8 @@
   <kbd class="mouse">Middle</kbd>-drag instead.
 </p>
 
+<p>
+  On macOS, where the middle click might not be available, the same effect
+  can be achieved by switching to the <a href="@@toolbox">Lock mode</a>
+  (as opposed to Slide or Ripple) in the top-left area of the screen.
+</p>


### PR DESCRIPTION
There might be no middle click on macOS to keep regions aligned, but there's a workaround.