### PR TITLE
The default fade type can be set in settings.

### DIFF
--- a/include/create-region-fades-and-crossfades.html
+++ b/include/create-region-fades-and-crossfades.html
@@ -77,6 +77,10 @@
   disables the region fade.
 </p>
 <p>
+  Ardour has a setting for the type of fade that's used by default. It can be
+  changed in the Edit → Preference → Editor menu.
+</p>
+<p>
   Because each fade is also a crossfade, it has an inverse fade shape
   for the audio beneath the fade. It is important to know how the
   shapes differ, and which are most suitable for various editing tasks.


### PR DESCRIPTION
This is based on discussion on forums at:

https://discourse.ardour.org/t/set-the-default-fade-type-when-splitting-regions/111361/2