### PR TITLE
Changes to Generic MIDI Maps

### DIFF
--- a/include/generic-midi-binding-maps.html
+++ b/include/generic-midi-binding-maps.html
@@ -399,6 +399,25 @@ bindings"&gt;
   keybinding definition.
 </p>
 
+<h4>Transport controls via MMC</h4>
+<p>
+  Some controllers like the Arturia KeyLab 49 have transport control
+  buttons that send MIDI Machine Control (MMC) commands by default. In
+  Ardour, MMC commands are mapped automatically to their corresponding
+  transport functions, but need to be received on the
+  <code>ardour:MMC in</code> MIDI port. In <kbd class="menu">Window
+  &gt; MIDI Connections</kbd>, ensure that the MIDI controller is
+  connected to the <code>MMC in</code> port found in the <code>Ardour
+  Misc</code> right-hand side tab.
+</p>
+<p>
+  Additionally
+  in <a href="@@preferences#preferences-transport-chase"> Transport &gt; Chase
+  </a> preferences, make sure that <dfn>Respond to MMC commands</dfn>
+  is checked and <dfn>Inbound MMC device ID:</dfn> is the same as the
+  MIDI controller's internal setting (usually 127 or 0).
+</p>
+
 <h3>Banks and Banking</h3>
 <p>
   Because many modern control surfaces offer per-track/bus controls

--- a/include/generic-midi-binding-maps.html
+++ b/include/generic-midi-binding-maps.html
@@ -30,8 +30,9 @@
   <li>Alesis QX25</li>
   <li>Alesis VI25</li>
   <li>Arturia KeyLab 49</li>
-  <li>Arturia MiniLab mk2</li>
+  <li>Arturia Keylab 49/61/88 mk2 (MCU/Analog Lab mode)</li>
   <li>Arturia MiniLab 3</li>
+  <li>Arturia MiniLab mk2</li>
   <li>Behringer BCF2000 Factory Preset 2</li>
   <li>Behringer BCF2000 Mackie Control</li>
   <li>Behringer DDX3216</li>
@@ -45,26 +46,30 @@
   <li>Korg nanoKONTROL2</li>
   <li>Korg nanoKONTROL2 With Master</li>
   <li>Korg Taktile (mode 9)</li>
-  <li>M-Audio Oxygen61 V3 by samtuke</li>
+  <li>LAudio EASYCONTROL.9</li>
   <li>M-Audio Axiom 25 - Transport Controls</li>
+  <li>M-Audio Axiom 49 MkII</li>
   <li>M-Audio Axiom 61</li>
-  <li>M-Audio Axiom Air 25 (2015 Model) - Transport Controls</li>
   <li>M-Audio Axiom AIR Mini 32</li>
-  <li>M-Audio Oxygen8 V2</li>
-  <li>M-Audio Oxygen25 (factory default)</li>
-  <li>M-Audio Oxygen25 (3rd Gen)</li>
+  <li>M-Audio Axiom Air 25 (2015 Model) - Transport Controls</li>
   <li>M-Audio Oxygen 49</li>
-  <li>M-Audio Oxygen 61 v3</li>
-  <li>WiiMote via midikb</li>
+  <li>M-Audio Oxygen 61 v3</l>
+  <li>M-Audio Oxygen25 (3rd Gen)</li>
+  <li>M-Audio Oxygen25 (factory default)</li>
+  <li>M-Audio Oxygen61 V3 by samtuke</li>
+  <li>M-Audio Oxygen8 V2</li>
+  <li>Nektar Impact GX</li>
+  <li>Nektar Impact LX</li>
   <li>Nektar Panorama</li>
   <li>Novation Impulse 49</li>
   <li>Novation Impulse 61</li>
   <li>Novation Launch Control XL</li>
-  <li>Novation Launchkey 25</li>
   <li>Novation LaunchKey 49</li>
+  <li>Novation Launchkey 25</li>
   <li>Roland A-30</li>
   <li>Roland SI-24</li>
   <li>Roland V-Studio 20</li>
+  <li>WiiMote via midikb</li>
   <li>Yamaha KX25 Transport Controls</li>
 </ul>
 <p>


### PR DESCRIPTION
The list of presets is not up-to-date, so I'm adding the missing ones and re-ordering the list as they appear in the dropdown in Ardour.

I'm also adding a section on getting transport controls to work with a controller that sends MMC commands by default. _**Context**_: I got an Arturia Keylab 88 a while back, but couldn't get the transport buttons to work given the keyboard's default settings. I had thought it could be a bug, but it turns out I only had to connect the controller to the `MMC in` port. There was nothing in the docs that mentioned this, and I only figured it out after messing with the code :exploding_head: 

