### PR TITLE
Remove duplicate subtitle on book recommendation

### DIFF
--- a/include/metering-in-ardour.html
+++ b/include/metering-in-ardour.html
@@ -38,7 +38,7 @@
 <ul>
   <li><a href="http://www.digido.com/how-to-make-better-recordings-part-2.html">How To Make Better Recordings in the 21st Century&mdash;An Integrated Approach to Metering, Monitoring, and Leveling Practices</a> by Bob Katz. Has a good historic overview of meters and motivates the K-meter</li>
   <li><a href="https://en.wikipedia.org/wiki/Peak_programme_meter#Table_of_characteristics">Wikipedia: Peak programme meter</a>&mdash;overview of meter types.</li>
-  <li>"Audio Metering: Measurements, Standards and Practice: Measurements, Standards and Practice", by Eddy Brixen. ISBN: 0240814673</li>
+  <li>"Audio Metering: Measurements, Standards and Practice", by Eddy Brixen. ISBN: 0240814673</li>
   <li>"Art of Digital Audio", by John Watkinson. ISBN: 0240515870</li>
 </ul>
 


### PR DESCRIPTION
Fix title of the book which doesn't need to have the subtitle listed twice.